### PR TITLE
Add default symbol if gear.circle.fill is mising

### DIFF
--- a/hello/UI/Provisioning/PrimaryStatus.swift
+++ b/hello/UI/Provisioning/PrimaryStatus.swift
@@ -105,8 +105,16 @@ struct StageRow: View {
                         }
                 // Catchall for pending
                 } else {
-                    Image(systemName: "gear.circle.fill")
+                    // Handle Big Sur and Monterey. A little janky.
+                    let gearSymbol: Image? = Image(systemName: "gear.circle.fill")
+                    let questionSymbol: Image? = Image(systemName: "questionmark.square.fill")
+                    if gearSymbol != nil {
+                        gearSymbol
                         .foregroundColor(.secondary)
+                    } else {
+                        questionSymbol
+                        .foregroundColor(.secondary)
+                    }
                     Text("Pending")
                         .frame(width: 75)
                         .onAppear {


### PR DESCRIPTION
This isn't exactly what you mentioned, but I had issues with that pattern. This one is more lines and slightly more messy, but it seems to work:

When gear.circle.filled is present:
<img width="1012" alt="Screen Shot 2021-10-17 at 4 53 48 PM" src="https://user-images.githubusercontent.com/867868/137644664-75ac0237-f888-4c5a-8858-48947f81da3d.png">

And when its not (I set it to `nil` manually) :

<img width="1012" alt="Screen Shot 2021-10-17 at 4 53 32 PM" src="https://user-images.githubusercontent.com/867868/137644679-b541394b-4403-4116-a26e-c0cd52b37065.png">

